### PR TITLE
qf_init: Do not use fallocate on macOS

### DIFF
--- a/config.h
+++ b/config.h
@@ -1,0 +1,10 @@
+#ifndef CONFIG_H
+#define CONFIG_H 1
+
+#if __linux__
+# define HAVE_FALLOCATE
+#else
+# undef HAVE_FALLOCATE
+#endif
+
+#endif

--- a/threadsafe-gqf/gqf.c
+++ b/threadsafe-gqf/gqf.c
@@ -1,3 +1,4 @@
+#include "config.h"
 #include <stdlib.h>
 #if 0
 # include <assert.h>
@@ -1523,11 +1524,13 @@ void qf_init(QF *qf, uint64_t nslots, uint64_t key_bits, uint64_t value_bits,
 			perror("Couldn't open file:\n");
 			exit(EXIT_FAILURE);
 		}
+#if HAVE_FALLOCATE
 		ret = fallocate(qf->mem->fd, 0, 0, size+sizeof(qfmetadata));
 		if (ret < 0) {
-			perror("Couldn't fallocate file:\n");
+			perror("Couldn't posix_fallocate file:\n");
 			exit(EXIT_FAILURE);
 		}
+#endif
 		qf->metadata = (qfmetadata *)mmap(NULL, size+sizeof(qfmetadata), PROT_READ |
 																			PROT_WRITE, MAP_SHARED, qf->mem->fd, 0);
 


### PR DESCRIPTION
Fix the error: use of undeclared identifier 'fallocate'
macOS does not have fallocate. It does have `fcntl` `F_PREALLOCATE`.
See for example https://github.com/trbs/fallocate/blob/master/fallocate/_fallocatemodule.c#L59