### PR TITLE
minor change to add -L/usr/local/lib/ before -lz in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ LD= g++ -std=c++11
 
 CXXFLAGS += -Wall $(DEBUG) $(PROFILE) $(OPT) $(ARCH) -m64 -I. -Wno-unused-result -Wno-strict-aliasing -Wno-unused-function -Wno-sign-compare
 
-LDFLAGS += $(DEBUG) $(PROFILE) $(OPT) -lpthread -lboost_system -lboost_thread -lm -lbz2 -lz
+LDFLAGS += $(DEBUG) $(PROFILE) $(OPT) -L/usr/local/lib/ -lpthread -lboost_system -lboost_thread -lm -lbz2 -lz
 
 #
 # declaration of dependencies


### PR DESCRIPTION
This change will allow the code to compile on CentOS. Of course, you'll probably need devtools and an updated zlib, but with this minor change to the Makefile it will compile.

Note, I have not tested that this does not break things on Ubuntu (yet) but I don't believe it will