### PR TITLE
qf_serialize: Add the filename to the error message

### DIFF
--- a/threadsafe-gqf/gqf.c
+++ b/threadsafe-gqf/gqf.c
@@ -1770,7 +1770,8 @@ void qf_serialize(const QF *qf, const char *filename)
 	FILE *fout;
 	fout = fopen(filename, "wb+");
 	if (fout == NULL) {
-		perror("Error opening file for serializing\n");
+		fputs("Error opening file for serializing: ", stderr);
+		perror(filename);
 		exit(EXIT_FAILURE);
 	}
 


### PR DESCRIPTION
The current error message does not include the filename, which makes it difficult to troubleshoot.
```
==> /usr/local/Cellar/squeakr/0.5/bin/squeakr-count 0 20 1 /usr/local/Cellar/squeakr/0.5/share/squeakr/test.fastq
Error opening file for serializing
: Operation not permitted
Error: brewsci/bio/squeakr: failed
```
This PR improves the error message by adding the filename to the error:
```
Error opening file for serializing: path/to/filename.foo: Operation not permitted
```
I'd suggest making this change to each call to `perror`.

See https://github.com/brewsci/homebrew-bio/pull/68#issuecomment-368738976 cc @tseemann